### PR TITLE
Hide clear buttons when hash EditText fields is empty

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Checklist
+
+__Common__
+
+- [ ] I am ran the app before creating PR
+- [ ] I am ran all tests before creating PR
+
+__UI__
+
+- [ ] I am ran the app for visual checks.
+
+__Logic__
+
+- [ ] I am tested basic app functionality.
+
+## Changes
+
+Describe all changes here:
+
+- First;
+- Second;
+- Third;
+- ...
+
+## Comments
+
+Describe all additional information here.

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Screenshots (Light theme)
 
 <br/>
 <p align="center">
-  <img src="media/screenshots/screenshot_01.png" width="170" />
-  <img src="media/screenshots/screenshot_02.png" width="170" />
-  <img src="media/screenshots/screenshot_03.png" width="170" />
-  <img src="media/screenshots/screenshot_04.png" width="170" />
-  <img src="media/screenshots/screenshot_05.png" width="170" />
+  <img src="media/screenshots/screenshot_01.png" width="130" />
+  <img src="media/screenshots/screenshot_02.png" width="130" />
+  <img src="media/screenshots/screenshot_03.png" width="130" />
+  <img src="media/screenshots/screenshot_04.png" width="130" />
+  <img src="media/screenshots/screenshot_05.png" width="130" />
 </p>
 
 Screenshots (Dark theme)
@@ -66,11 +66,11 @@ Screenshots (Dark theme)
 
 <br/>
 <p align="center">
-  <img src="media/screenshots/screenshot_06.png" width="170" />
-  <img src="media/screenshots/screenshot_07.png" width="170" />
-  <img src="media/screenshots/screenshot_08.png" width="170" />
-  <img src="media/screenshots/screenshot_09.png" width="170" />
-  <img src="media/screenshots/screenshot_10.png" width="170" />
+  <img src="media/screenshots/screenshot_06.png" width="130" />
+  <img src="media/screenshots/screenshot_07.png" width="130" />
+  <img src="media/screenshots/screenshot_08.png" width="130" />
+  <img src="media/screenshots/screenshot_09.png" width="130" />
+  <img src="media/screenshots/screenshot_10.png" width="130" />
 </p>
 
 Downloads

--- a/app/src/main/java/com/smlnskgmail/jaman/hashchecker/logic/hashcalculator/ui/HashCalculatorFragment.java
+++ b/app/src/main/java/com/smlnskgmail/jaman/hashchecker/logic/hashcalculator/ui/HashCalculatorFragment.java
@@ -14,7 +14,9 @@ import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
 import android.provider.OpenableColumns;
 import android.provider.Settings;
+import android.text.Editable;
 import android.text.InputFilter;
+import android.text.TextWatcher;
 import android.text.method.ScrollingMovementMethod;
 import android.view.View;
 import android.widget.Button;
@@ -464,6 +466,50 @@ public class HashCalculatorFragment extends BaseFragment
 
         ImageView ivGeneratedHashClear = view.findViewById(R.id.iv_generated_hash_clear);
         ivGeneratedHashClear.setOnClickListener(v -> etGeneratedHash.setText(""));
+
+        etCustomHash.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                int writtenTextLength = s.toString().length();
+                if(writtenTextLength > 0) {
+                    ivCustomHashClear.setVisibility(View.VISIBLE);
+                }else {
+                    ivCustomHashClear.setVisibility(View.GONE);
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
+
+        etGeneratedHash.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                int writtenTextLength = s.toString().length();
+                if(writtenTextLength > 0) {
+                    ivGeneratedHashClear.setVisibility(View.VISIBLE);
+                }else {
+                    ivGeneratedHashClear.setVisibility(View.GONE);
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+
+            }
+        });
 
         tvSelectedObjectName = view.findViewById(R.id.tv_selected_object_name);
 


### PR DESCRIPTION
## Checklist

__Common__

- [x] I am ran the app before creating PR
- [ ] I am ran all tests before creating PR

__UI__

- [x] I am ran the app for visual checks.

__Logic__

- [x] I am tested basic app functionality.

## Changes

Describe all changes here:

- First; Hide clear button (ivCustomHashClear) when hash EditText (etCustomHash) is empty
- Second; Hide clear button (ivGeneratedHashClear) when hash EditText (etGeneratedHash) is empty

## Comments

Describe all additional information here.
